### PR TITLE
Support indent with 2 spaces

### DIFF
--- a/bake/bakefile.py
+++ b/bake/bakefile.py
@@ -185,8 +185,9 @@ class Bakefile:
         return shebang.strip().endswith("sh")
 
     def _is_task_line(self, line):
-        if line.startswith(INDENT_STYLES[0]) or line.startswith(INDENT_STYLES[1]):
-            return True
+        for item in INDENT_STYLES:
+            if line.startswith(item):
+                return True
 
     @staticmethod
     def _is_shebang_line(line):

--- a/bake/constants.py
+++ b/bake/constants.py
@@ -1,4 +1,4 @@
-INDENT_STYLES = ("\t", " " * 4)
+INDENT_STYLES = ("\t", " " * 4, " " * 2)
 SKIP_NEXT = False
 SAFE_ENVIRONS = [
     "HOME",


### PR DESCRIPTION
It might be helpful if bake understands Bakefiles indented with 2 spaces.

Fixes #19 